### PR TITLE
fix(eslint): array newline and spacing rules

### DIFF
--- a/packages/eslint-config/src/plugins/eslint/rules.ts
+++ b/packages/eslint-config/src/plugins/eslint/rules.ts
@@ -1,8 +1,12 @@
 export = {
 	rules: {
+		// todo: re-evaluate array-bracket / array-element rules
 		'array-bracket-newline': ['error', {minItems: 4}],
 		'array-bracket-spacing': ['error', 'never', {arraysInArrays: true}],
-		'array-element-newline': ['error', {minItems: 4}],
+		'array-element-newline': ['error', {
+			ArrayExpression: 'consistent',
+			ArrayPattern: {minItems: 3}
+		}],
 		'arrow-parens': ['error', 'as-needed'],
 		'arrow-spacing': 'error',
 		'comma-style': ['error', 'last'],

--- a/packages/eslint-config/src/plugins/eslint/rules.ts
+++ b/packages/eslint-config/src/plugins/eslint/rules.ts
@@ -1,12 +1,8 @@
 export = {
 	rules: {
-		// todo: re-evaluate array-bracket / array-element rules
-		'array-bracket-newline': ['error', {minItems: 4}],
-		'array-bracket-spacing': ['error', 'never', {arraysInArrays: true}],
-		'array-element-newline': ['error', {
-			ArrayExpression: 'consistent',
-			ArrayPattern: {minItems: 3}
-		}],
+		'array-bracket-newline': ['error', {multiline: true, minItems: 4}],
+		'array-bracket-spacing': ['error', 'never', {arraysInArrays: true, objectsInArrays: true}],
+		'array-element-newline': ['error', {multiline: true, minItems: 4}],
 		'arrow-parens': ['error', 'as-needed'],
 		'arrow-spacing': 'error',
 		'comma-style': ['error', 'last'],


### PR DESCRIPTION
## Description
- Add `multiline: true` to `array-bracket-newline` and `array-element-newline`
- Add `objectsInArrays: true` to array-bracket-spacing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (change to docs, jsdocs, comments, etc)
- [ ] Style (change to code style, formatting, and/or linting)
- [ ] Test (change or add tests)
- [ ] Refactor (change which doesn't affect functionality)
- [ ] Other (change which doesn't fit into any of the above categories)

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly if needed.
- [ ] I have added tests to cover my changes if needed.
- [x] All new and existing tests passed.
