### PR TITLE
feat(semantic-release): add default branches config

### DIFF
--- a/packages/semantic-release/__tests__/config-compiled.test.ts
+++ b/packages/semantic-release/__tests__/config-compiled.test.ts
@@ -5,8 +5,21 @@ describe('config-compiled', () => {
 		expect(config).toBeInstanceOf(Object)
 	})
 
-	it('should have a branches property equalling ["main", "next"]', () => {
-		expect(config.branches).toStrictEqual(['main', 'next'])
+	it('should have a branches that matches the default semantic-release config (with main instead of master)', () => {
+		expect(config.branches).toStrictEqual([
+			'+([0-9])?(.{+([0-9]),x}).x',
+			'main',
+			'next',
+			'next-major',
+			{
+				name: 'beta',
+				prerelease: true
+			},
+			{
+				name: 'alpha',
+				prerelease: true
+			}
+		])
 	})
 
 	describe('plugins', () => {
@@ -32,6 +45,6 @@ describe('config-compiled', () => {
 	})
 
 	it('should have a plugin where the first element is "@semantic-release/commit-analyzer" and the second element is {preset: "conventionalcommits"}', () => {
-		expect(config.plugins).toContainEqual(['@semantic-release/commit-analyzer', {preset: 'conventionalcommits'}])
+		expect(config.plugins).toContainEqual(['@semantic-release/commit-analyzer', {preset: 'conventionalcommits'} ])
 	})
 })

--- a/packages/semantic-release/__tests__/config.test.ts
+++ b/packages/semantic-release/__tests__/config.test.ts
@@ -5,8 +5,21 @@ describe('config', () => {
 		expect(config).toBeInstanceOf(Object)
 	})
 
-	it('should have a branches property equalling ["main", "next"]', () => {
-		expect(config.branches).toStrictEqual(['main', 'next'])
+	it('should have a branches that matches the default semantic-release config (with main instead of master)', () => {
+		expect(config.branches).toStrictEqual([
+			'+([0-9])?(.{+([0-9]),x}).x',
+			'main',
+			'next',
+			'next-major',
+			{
+				name: 'beta',
+				prerelease: true
+			},
+			{
+				name: 'alpha',
+				prerelease: true
+			}
+		])
 	})
 
 	describe('plugins', () => {
@@ -32,6 +45,6 @@ describe('config', () => {
 	})
 
 	it('should have a plugin where the first element is "@semantic-release/commit-analyzer" and the second element is {preset: "conventionalcommits"}', () => {
-		expect(config.plugins).toContainEqual(['@semantic-release/commit-analyzer', {preset: 'conventionalcommits'}])
+		expect(config.plugins).toContainEqual(['@semantic-release/commit-analyzer', {preset: 'conventionalcommits'} ])
 	})
 })

--- a/packages/semantic-release/src/index.ts
+++ b/packages/semantic-release/src/index.ts
@@ -8,7 +8,14 @@ for (const plugin of Object.values(pluginConfigs)) {
 }
 
 const config: Partial<SemanticRelease.GlobalConfig> = {
-	branches: ['main', 'next'],
+	branches: [
+		'+([0-9])?(.{+([0-9]),x}).x',
+		'main',
+		'next',
+		'next-major',
+		{name: 'beta', prerelease: true},
+		{name: 'alpha', prerelease: true}
+	],
 	plugins
 }
 


### PR DESCRIPTION
## Description
Adds the default configuration for branches from sematic-release:
- main
- next
- next-major
- beta
- alpha
- x.x.x

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (change to docs, jsdocs, comments, etc)
- [ ] Style (change to code style, formatting, and/or linting)
- [ ] Test (change or add tests)
- [ ] Refactor (change which doesn't affect functionality)
- [ ] Other (change which doesn't fit into any of the above categories)

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly if needed.
- [ ] I have added tests to cover my changes if needed.
- [ ] All new and existing tests passed.
